### PR TITLE
Уменьшение размера образа nginx

### DIFF
--- a/conf/nginx/Dockerfile
+++ b/conf/nginx/Dockerfile
@@ -2,16 +2,11 @@ FROM nginx:1.10.1
 
 MAINTAINER Stepanov Nikolai <nstepanovdev@gmail.com>
 
-RUN mkdir -p /tmp/nginx && mkdir -p /tmp/nginx/cache && mkdir -p /tmp/nginx/cache
-
-CMD "/bin/bash"
-
-RUN usermod -u 1000 -d /data -s /bin/bash www-data
-RUN mkdir /data && chmod -R 775 /data && find /data -type d -exec chmod 775 {} \;
+RUN mkdir -p /tmp/nginx && mkdir -p /tmp/nginx/cache && mkdir -p /tmp/nginx/cache \
+	&& usermod -u 1000 -d /data -s /bin/bash www-data \
+	&& mkdir /data && chmod -R 775 /data && find /data -type d -exec chmod 775 {} \;
 
 COPY conf /etc/nginx
 
 WORKDIR /data
 CMD ["nginx"]
-
-


### PR DESCRIPTION
каждый вызов команды в Dockerfile вызывает порождение нового слоя, что в большинстве случаев излишне. И по bestpractice docker рекомендуют объединять RUN и прочие команды в одну, а иногда и скрипты делают чтоб уменьшить количество команд