### PR TITLE
Many changes

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,5 +1,6 @@
 TZ=Europe/Moscow
 SHELL=/bin/zsh
+HOSTIP=127.0.0.1
 
 SYMFONY_ENV=dev
 MYSQL_ROOT_PASSWORD=root

--- a/.env.dist
+++ b/.env.dist
@@ -1,6 +1,9 @@
 TZ=Europe/Moscow
 SHELL=/bin/zsh
 HOSTIP=127.0.0.1
+#HOSTIP=docker.for.mac.localhost
+DNS1=8.8.8.8
+DNS2=8.8.4.4
 
 SYMFONY_ENV=dev
 MYSQL_ROOT_PASSWORD=root

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ mv ./test ./workspace
   Network Adapter Setting
 ```
 
-set your local dns server to `127.0.0.1` .
+set your local dns server to `127.0.0.1` , to prevent dnsmasq from running, you need to **set up the second DNS server**. Such as 8.8.8.8 or something else.
 
 - Then open http://test.php.dev/ in your browser
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -82,16 +82,35 @@ $ cp -R ~/.ssh ~/www/docker/stacker/workspace
 
 ## 常见问题
 
-#### 怎么配置数据库密码？
+#### 怎么设置数据库密码？
 修改`.env`文件里面数据库密码的参数。
 
-#### stacker 的端口号都是什么？
+#### 如何在项目中连接容器？
 
-- MySQL：3307
-- PostgreSQL：5433
-- Redis：6379
-- MailCatcher：1025、1080
-- 更多请查看`docker-compose.yml`
+- 数据库
+
+  ```yaml
+    # Example for mysql
+    parameters:
+      database_host: mysql #主机就填mysql
+      database_port: 3306
+      database_name: sf
+      database_user: root
+      database_password: root
+
+    # Example for pgsql
+    parameters:
+      database_host: pgsql #主机就填pgsql
+      database_port: 5433
+      database_name: sf
+      database_user: postgres
+      database_password: postgres
+    
+    # Example for redis
+    parameters:
+      database_host: redis #主机就填redis
+      database_port: 6379
+  ```
 
 #### Xdebug + PhpStorm 配置 
 
@@ -107,12 +126,8 @@ $ cp -R ~/.ssh ~/www/docker/stacker/workspace
   remove a directory `./workspace` and rename your link to workspace - that's all! 
   Now all your Symfony projects is available from the browser.
 
-#### 怎么连接到 stacker 容器呢？
-你可以这样
-```sh 
-$ /your_path/to_stacker_folder/bin/stacker console
-```
-不过最好将他添加到系统变量中，更加方便。
+#### 怎么使用终端？
+将 stacker 添加到系统变量中，
 ```sh
 # for bash
 $ echo 'export PATH=/your_path/to_stacker_folder/bin:$PATH' >> ~/.bashrc && source ~/.bashrc 
@@ -121,6 +136,11 @@ $ echo 'export PATH=/your_path/to_stacker_folder/bin:$PATH' >> ~/.zshrc && sourc
 # then restart console and run
 $ stacker console
 ```
+然后
+```sh 
+$stacker console
+```
+
 
 #### Symfony completion
 ```sh

--- a/README_cn.md
+++ b/README_cn.md
@@ -66,7 +66,7 @@ $ mv ./test ./workspace
   在 网络适配器设置 --> TCP/IP协议 中
 ```
 
-将你的DNS服务器设置为`127.0.0.1`
+将你的DNS服务器设置为`127.0.0.1`，为了防止dnsmasq出现故障，你必须设置第二dns服务器，比如114.114.114.114或者其他。
 
 - 在浏览器中打开 http://test.php.dev/
 - [示例视频](https://youtu.be/42BemUfK5-4)

--- a/README_cn.md
+++ b/README_cn.md
@@ -8,36 +8,34 @@
 [![License](https://poser.pugx.org/maxlab/stacker/license)](https://packagist.org/packages/maxlab/stacker)
 [![Latest Unstable Version](https://poser.pugx.org/maxlab/stacker/v/unstable)](https://packagist.org/packages/maxlab/stacker)
 
-## 简介
+# Stacker
 
 - [English](https://github.com/Maxlab/stacker)
 - [简体中文](https://github.com/Maxlab/stacker/blob/master/README_cn.md)
 
-#### 为什么选择 stacker?
-Stacker - 满足你 Web 开发的所有需要，让你像着魔一般爱上stacker。
+#### Stacker 是什么?
+Stacker 是一个 Docker 项目，几乎包含了 Web 开发的所有环境 Node.js、PHP、MySQL、PostgreSQL、Redis、Elasticsearch等等。
 
-- **包含Web开发需要的一切**
-  - 后端开发：MySQL & PostgreSQL 、Nginx & Apache、PHP 7&5、xdebug、Redis、Elasticsearch
-  - 前端开发：nodejs, gem, npm, webpack, bower, gulp, uglify-js, uglifycss
-  - 其他工具：
-    - MailCatcher
-      - 可以方便的本地调试验证邮件之类的东西，无需使用`mailtrap`之类的服务。
-      - 所有外发邮件会发送至 http://mail.dev/
-    - 自动部署：[dep](https://deployer.org/)
-    - 容器终端采用的是 *ZSH* + [oh-my-zsh](http://ohmyz.sh/)
+#### Stacker 特色功能？
 
-- 快捷的管理命令
+- **邮件外发调试**
 
-  请看下面常见问题中的 “**怎么连接到 stacker 容器**” 然后才可使用 `stacker` 命令。
+  将你的应用的发信服务器设置为 `mailcatcher` ，端口设置为 `1025` 就可以在 http://mail.dev 中查看应用发出的邮件啦
 
-  - stacker [ps build down up start stop logs … ]
-    - 查看日志 `stacker logs -f`
+- **使用PHPStorm调试PHP应用**
 
-## 系统需求
-- 已安装 [Docker](https://docs.docker.com/)
-- 已安装 [Docker Compose](https://docs.docker.com/compose/install/) > 1.8.0
+  - 查看 [视频](https://youtu.be/RdmcGAAQGfI) 教程 (俄语)
+
+  1. Go to Settings -> Languages & Frameworks -> PHP
+  2. Click the ... behind your interperter
+
+- **绿色便携的 PHP & Node 终端**
+
+  宿主机无需安装 PHP 及 Node.js 即可使用 `stacker console` 在你的项目中执行 `php hello.php` 和 `ndoe hello.js` 。
 
 ## 安装
+
+安装之前请先安装 [Docker](https://docker.com) 。
 
 #### 获取 stacker ： 
 ```sh 
@@ -111,13 +109,6 @@ $ cp -R ~/.ssh ~/www/docker/stacker/workspace
       database_host: redis #主机就填redis
       database_port: 6379
   ```
-
-#### Xdebug + PhpStorm 配置 
-
-- Watch [this video](https://youtu.be/RdmcGAAQGfI) (in Russian)
-
-1. Go to Settings -> Languages & Frameworks -> PHP
-2. Click the ... behind your interperter
 
 #### I have a lot of the Symfony project, is it possible to make a symbolic link to them? 
 - Yes! It's much faster and easier, plus no need to move folders from the usual places.

--- a/bin/dev_command/mysqldump
+++ b/bin/dev_command/mysqldump
@@ -1,3 +1,3 @@
 
-cd ${DEV_WORKDIR} && docker-compose exec db bash -c 'mysqldump -uroot -p${MYSQL_ROOT_PASSWORD} ${DEV_COMMAND_OPTIONS}'
+cd ${DEV_WORKDIR} && docker-compose exec mysql bash -c 'mysqldump -uroot -p${MYSQL_ROOT_PASSWORD} ${DEV_COMMAND_OPTIONS}'
 exit $?;

--- a/conf/dnsmasq/Dockerfile
+++ b/conf/dnsmasq/Dockerfile
@@ -1,8 +1,14 @@
 FROM alpine:latest
-MAINTAINER vc@nic.com.gy
+MAINTAINER Naiwa(vc@nic.com.gy)
 
 RUN apk --no-cache add dnsmasq
 COPY dnsmasq.conf /etc/dnsmasq.conf
+
+ARG DNS1
+ARG DNS2
+RUN echo server=$DNS1>>/etc/dnsmasq.conf \
+	&& echo server=$DNS2>>/etc/dnsmasq.conf \
+	&& cat /etc/dnsmasq.conf
 
 EXPOSE 53 53/udp
 

--- a/conf/dnsmasq/Dockerfile
+++ b/conf/dnsmasq/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER vc@nic.com.gy
 RUN apk --no-cache add dnsmasq
 COPY dnsmasq.conf /etc/dnsmasq.conf
 
-EXPOSE 53 53
 EXPOSE 53 53/udp
 
 ENTRYPOINT ["dnsmasq", "-k"]

--- a/conf/dnsmasq/dnsmasq.conf
+++ b/conf/dnsmasq/dnsmasq.conf
@@ -1,4 +1,7 @@
+no-hosts
 no-resolv
-server=8.8.4.4
-server=8.8.8.8
+strict-order
+
 address=/.dev/127.0.0.1
+
+all-servers

--- a/conf/php7xdebug/Dockerfile
+++ b/conf/php7xdebug/Dockerfile
@@ -58,7 +58,7 @@ RUN pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)\n" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_connect_back=1" >> /usr/local/etc/php/conf.d/xdebug.ini
+    && echo "xdebug.remote_connect_back=0" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # common
 RUN docker-php-ext-install opcache calendar dba pcntl bcmath mbstring xmlrpc ftp shmop mysqli

--- a/conf/php7xdebug/Dockerfile
+++ b/conf/php7xdebug/Dockerfile
@@ -87,6 +87,12 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY etc/php-fpm.conf /usr/local/etc/
 COPY etc/php.ini /usr/local/etc/php/
+
+# Put host's IP to php.ini
+ARG HOSTIP=127.0.0.1
+ENV HOSTIP ${HOSTIP}
+RUN echo xdebug.remote_host=$HOSTIP>>/usr/local/etc/php/conf.d/xdebug.ini
+
 RUN chmod ugo+rX -R /usr/local/etc/php
 
 # SSH

--- a/conf/php7xdebug/etc/php.ini
+++ b/conf/php7xdebug/etc/php.ini
@@ -10,8 +10,6 @@ upload_max_filesize = 64M
 [xdebug]
 xdebug.remote_enable=1
 xdebug.cli_color=1
-xdebug.remote_host=127.0.0.1
-#xdebug.remote_host="docker.for.mac.localhost" #for mac
 xdebug.collect_params=0
 xdebug.collect_return=0
 xdebug.collect_vars=0

--- a/conf/php7xdebug/etc/php.ini
+++ b/conf/php7xdebug/etc/php.ini
@@ -11,6 +11,7 @@ upload_max_filesize = 64M
 xdebug.remote_enable=1
 xdebug.cli_color=1
 xdebug.remote_host=127.0.0.1
+#xdebug.remote_host="docker.for.mac.localhost" #for mac
 xdebug.collect_params=0
 xdebug.collect_return=0
 xdebug.collect_vars=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
         
     mysql:
         image: mysql:5.7
+        container_name: mysql
         env_file: .env
         ports:
             - 3307:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,9 @@ services:
                 - TZ=${TZ}
             context: ./conf/php7console 
         container_name: php7console 
+        dns:
+            - ${DNS1}
+            - ${DNS2}
         image: maxlab/php7console
         restart: always        
         volumes_from:
@@ -86,6 +89,9 @@ services:
                 - HOSTIP=${HOSTIP}
             context: ./conf/php7xdebug
         image: maxlab/php7xdebug
+        dns:
+            - ${DNS1}
+            - ${DNS2}
         restart: always
         volumes:
             - ./workspace:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,12 +97,16 @@ services:
             - elasticsearch
 
     dnsmasq:
+        env_file: .env
         build:
+            args:
+                - DNS1=${DNS1}
+                - DNS2=${DNS2}
             context: ./conf/dnsmasq
         ports:
             - "53:53"
             - "53:53/udp"
-        cap_add:  
+        cap_add:
             - NET_ADMIN
         restart: always
             

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
         build:
             context: ./conf/dnsmasq
         ports:
+            - "53:53"
             - "53:53/udp"
         cap_add:  
             - NET_ADMIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,9 @@ services:
     php7xdebug:
         env_file: .env
         build:
+            args:
+                - TZ=${TZ}
+                - HOSTIP=${HOSTIP}
             context: ./conf/php7xdebug
         image: maxlab/php7xdebug
         restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,6 @@ services:
         build:
             context: ./conf/dnsmasq
         ports:
-            - "53:53"
             - "53:53/udp"
         cap_add:  
             - NET_ADMIN


### PR DESCRIPTION
- fix `stacker mysql` and `stacker mysqldump` not work
- now you can config **xdebug**.remote_host and **dnsmasq**'s DNS servers in .env file.
- fix container's DNS requests may causes dnsmasq denial of service
- **all available** on MAC
- friendly with China (option DNS server, eg 114.114.114.114)